### PR TITLE
Try to disable parallelization

### DIFF
--- a/tests/Test.It.While.Hosting.Your.Web.Application.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Test.It.While.Hosting.Your.Web.Application.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
https://xunit.github.io/docs/running-tests-in-parallel

This can behave differently on 2-core build VM, than on local machine which probably has more cores.